### PR TITLE
Updated merge-stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/mixu/pipe-iterators",
   "dependencies": {
     "clone": "0.1.18",
-    "merge-stream": "0.1.6",
+    "merge-stream": "1.0.0",
     "miniq": "~1.0.0",
     "readable-stream": "*",
     "through2": "*",

--- a/test/control-flow.test.js
+++ b/test/control-flow.test.js
@@ -14,7 +14,8 @@ describe('match', function() {
           function(obj) { return obj % 2 == 0; },
           pi.toArray(twos),
           function(obj) { return obj % 3 == 0; },
-          pi.toArray(threes)
+          pi.toArray(threes),
+          pi.devnull()
         );
 
     assert.ok(isWritable(result));
@@ -33,7 +34,8 @@ describe('match', function() {
     var twos = [],
         result = pi.match(
           function(obj) { return obj % 2 == 0; },
-          pi.toArray(twos)
+          pi.toArray(twos),
+          pi.devnull()
         );
 
     assert.ok(isWritable(result));


### PR DESCRIPTION
In some cases, merge-stream caused issues when using via `pi.matchMerge`. Updating it to 1.0.0 solved the issue.

I ran into problems running the tests (with the old and new merge-version), so i've updated the `pi.match` tests.

See https://github.com/mixu/pipe-iterators/issues/1
